### PR TITLE
Add `read_full_line` and `lines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,9 @@ This file's format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/). The
 version number is tracked in the file `VERSION`.
 
+## Unreleased
+- Add methods `read_full_line` and `lines`, to allow safely reading full lines
+  from the buffer.
+
 ## 0.1.0
 - Initial public release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@
 //!
 //! Memory-based buffer which implements Write and Read traits.
 
+use std::cmp;
 use std::default::Default;
+use std::io;
 use std::result::Result::Ok;
 use std::sync::{Arc, Mutex};
-use std::io;
-use std::cmp;
 
 /// Simple object which implements both `std::io::Write` and `std::io::Read`.
 /// Uses an internal buffer. Thread-safe and cloneable.
@@ -72,6 +72,35 @@ impl io::Read for IoBuffer {
     }
 }
 
+impl IoBuffer {
+    /// Read a full line (terminated by `\n`), if any.  Any partial line is
+    /// left unread. The terminator is not included in the result.
+    pub fn read_full_line(&mut self) -> Option<Vec<u8>> {
+        let mut lock = self.inner.lock().expect("lock poisoned");
+        let mut p = lock.buf[lock.pos..].split(|c| *c == b'\n');
+        match p.next() {
+            Some(line) => {
+                match p.next() {
+                    Some(_rest) => {
+                        let line = line.to_vec();
+                        lock.pos += line.len() + 1;
+                        Some(line)
+                    }
+                    None => None, // incomplete line
+                }
+            }
+            None => None, // no data
+        }
+    }
+
+    /// Iterator of full lines (as returned by `read_full_line`).
+    pub fn lines(&mut self) -> Box<dyn Iterator<Item = Vec<u8>>> {
+        let mut buf = self.clone();
+        Box::new(std::iter::from_fn(move || buf.read_full_line()))
+    }
+}
+
+#[cfg(test)]
 mod tests {
     #![allow(unused_imports)] // these are required, but there's a warning for some reason
     use super::IoBuffer;
@@ -101,5 +130,34 @@ mod tests {
         );
         let s_out = String::from_utf8(dest).unwrap();
         assert!(s_out == (s1.to_string() + s2), "{}", s_out);
+    }
+
+    fn next_full_line(buf: &mut IoBuffer) -> Option<String> {
+        buf.read_full_line().map(|x| String::from_utf8(x).unwrap())
+    }
+
+    #[test]
+    fn test_partial_lines() {
+        let mut buf = IoBuffer::new();
+
+        assert_eq!(None, next_full_line(&mut buf));
+
+        write!(buf, "{}", "abc").unwrap();
+        assert_eq!(None, next_full_line(&mut buf));
+
+        write!(buf, "{}", "d\n").unwrap();
+        assert_eq!(Some("abcd".to_string()), next_full_line(&mut buf));
+        assert_eq!(None, next_full_line(&mut buf));
+
+        write!(buf, "{}", "e\n\nfghi\nj").unwrap();
+        assert_eq!(Some("e".to_string()), next_full_line(&mut buf));
+        assert_eq!(Some("".to_string()), next_full_line(&mut buf));
+        assert_eq!(Some("fghi".to_string()), next_full_line(&mut buf));
+        assert_eq!(None, next_full_line(&mut buf));
+
+        write!(buf, "{}", "\n").unwrap();
+        assert_eq!(Some("j".to_string()), next_full_line(&mut buf));
+        assert_eq!(None, next_full_line(&mut buf));
+        assert_eq!(None, next_full_line(&mut buf));
     }
 }


### PR DESCRIPTION
Add support for reading full lines from the `IoBuffer`, either one at a time or as an iterator.
